### PR TITLE
Fix crash in LLD when linking PIC code under specific circumstances.

### DIFF
--- a/ELF/Relocations.cpp
+++ b/ELF/Relocations.cpp
@@ -1117,6 +1117,8 @@ ThunkSection *ThunkCreator::getISThunkSec(InputSection *IS) {
   std::vector<InputSection *> *Range = nullptr;
   for (BaseCommand *BC : TOS->SectionCommands)
     if (auto *ISD = dyn_cast<InputSectionDescription>(BC)) {
+      if (ISD->Sections.size() == 0)
+	continue;
       InputSection *first = ISD->Sections.front();
       InputSection *last = ISD->Sections.back();
       if (IS->OutSecOff >= first->OutSecOff &&

--- a/test/ELF/linkerscript/Inputs/thunk-gen-mips-target.s
+++ b/test/ELF/linkerscript/Inputs/thunk-gen-mips-target.s
@@ -1,0 +1,10 @@
+	.text
+	.abicalls
+	.set    noreorder
+	.globl  too_far
+	.ent    too_far
+too_far:
+	nop
+	jr      $ra
+	nop
+	.end    too_far

--- a/test/ELF/linkerscript/thunk-gen-mips.s
+++ b/test/ELF/linkerscript/thunk-gen-mips.s
@@ -1,0 +1,25 @@
+# REQUIRES: mips
+# RUN:	llvm-mc -filetype=obj -triple=mips-unknown-freebsd %s -o %t
+# RUN:	llvm-mc -filetype=obj -triple=mips-unknown-freebsd %S/Inputs/thunk-gen-mips-target.s -o %t1
+
+# SECTIONS command with the first pattern that does not match.
+# Linking a PIC and non-PIC object files triggers the LA25 thunk generation.
+# RUN:		echo "SECTIONS { \
+# RUN:		.text : { \
+# RUN:			*(.nomatch) \
+# RUN:			%t(.text) \
+# RUN:			. = . + 0x100000 ; \
+# RUN:			%t1(.text) \
+# RUN:		} \
+# RUN:	}" > %t.script
+# RUN: ld.lld -o %t2 --script %t.script %t %t1
+# RUN: llvm-objdump -t %t2 | FileCheck %s
+# CHECK: SYMBOL TABLE:
+# CHECK-ANY: 00000000         .text           00000000 _start
+# CHECK-ANY: 0010000c l     F .text           00000010 __LA25Thunk_too_far
+# CHECK-ANY: 00100020 g     F .text           00000024 too_far
+
+.global _start
+_start:
+	j too_far
+	nop


### PR DESCRIPTION
The bug triggers when the following conditions are met:
    - A thunk is created in a given input section S
    - A linker script is specified
    - There is at least one matcher in the linker script .text section output
      that does not match any of the sections in the input files, before the matcher
      that matches section S.